### PR TITLE
Support for NDK r25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN apt-add-repository 'deb http://security.debian.org/debian-security stretch/u
 RUN apt-get update
 RUN apt-get install -yq openjdk-8-jre-headless openjdk-8-jdk-headless unzip wget cmake
 
-RUN rustup toolchain install 1.61.0
-RUN rustup default 1.61
+RUN rustup toolchain install 1.62.0
+RUN rustup default 1.62
 RUN rustc --version
 
 RUN rustup target add armv7-linux-androideabi
@@ -36,10 +36,10 @@ RUN ${ANDROID_HOME}/tools/bin/sdkmanager --update | grep -v = || true
 
 # Install Android NDK
 RUN cd /usr/local && \
-    wget -q http://dl.google.com/android/repository/android-ndk-r20-linux-x86_64.zip && \
-    unzip -q android-ndk-r20-linux-x86_64.zip && \
-    rm android-ndk-r20-linux-x86_64.zip
-ENV NDK_HOME /usr/local/android-ndk-r20
+    wget -q http://dl.google.com/android/repository/android-ndk-r25-linux.zip && \
+    unzip -q android-ndk-r25-linux.zip && \
+    rm android-ndk-r25-linux.zip
+ENV NDK_HOME /usr/local/android-ndk-r25
 
 # Copy contents to container. Should only use this on a clean directory
 COPY . /root/cargo-apk

--- a/src/ops/build.rs
+++ b/src/ops/build.rs
@@ -241,7 +241,6 @@ fn build_apks(
             .arg("1.7")
             .arg("-Xlint:deprecation")
             .arg("-bootclasspath")
-            // TODO: fix hardcoded path!
             .arg(rt_jar_path)
             .arg("-classpath")
             .arg(&classpath)

--- a/src/ops/build/targets.rs
+++ b/src/ops/build/targets.rs
@@ -40,4 +40,14 @@ impl AndroidBuildTarget {
             AndroidBuildTarget::X86_64 => "x86_64-linux-android",
         }
     }
+
+    // Returns just the architecture component for clang
+    pub fn clang_arch(self) -> &'static str {
+        match self {
+            AndroidBuildTarget::ArmV7a => "arm",
+            AndroidBuildTarget::Arm64V8a => "aarch64",
+            AndroidBuildTarget::X86 => "i386",
+            AndroidBuildTarget::X86_64 => "x86_64",
+        }
+    }
 }


### PR DESCRIPTION
Updated the Dockerfile to match and validated it builds and using it to build apks works as well with the commands below
```bash
docker build -t cargo-quad-apk:latest .
docker run --rm -v $(pwd):/root/src -w /root/src cargo-quad-apk:latest cargo quad-apk build --release
```