### PR TITLE
update to cargo 0.80

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,9 @@ repository = "https://github.com/not-fl3/cargo-apk"
 edition = "2018"
 
 [dependencies]
-cargo = "0.62.0"
-cargo-util = "0.1"
-clap = "3.1.0"
+cargo = "0.80"
+cargo-util = "0.2.9"
+clap = "4.5.4"
 itertools = "0.8.2"
 dirs = "2.0.2"
 anyhow = "1.0"

--- a/src/ops/build.rs
+++ b/src/ops/build.rs
@@ -48,7 +48,7 @@ pub fn build(
         &root_build_dir,
         &miniquad_root_path,
     )?;
-    let sign = !options.is_present("nosign");
+    let sign = !options.get_flag("nosign");
 
     build_apks(
         config,
@@ -268,8 +268,7 @@ fn build_apks(
         }
         // otherwise "Type `java.lang.System` was not found" error
         d8_cmd.arg("--no-desugaring");
-        d8_cmd.arg("--min-api")
-            .arg("26");
+        d8_cmd.arg("--min-api").arg("26");
 
         d8_cmd.cwd(&target_directory).exec()?;
 

--- a/src/ops/build/util.rs
+++ b/src/ops/build/util.rs
@@ -214,11 +214,11 @@ pub fn find_package_root_path(
         compiler::CompileTarget::new(first_build_target.rust_triple()).unwrap(),
     )];
 
-    let target_data = compiler::RustcTargetData::new(&workspace, &requested_kinds[..]).unwrap();
+    let mut target_data = compiler::RustcTargetData::new(&workspace, &requested_kinds[..]).unwrap();
     let cli_features = resolver::CliFeatures::new_all(false);
     let ws_resolve = cargo::ops::resolve_ws_with_opts(
         &workspace,
-        &target_data,
+        &mut target_data,
         &requested_kinds,
         &cli_features,
         &specs,
@@ -311,11 +311,11 @@ pub fn collect_java_files(workspace: &Workspace, config: &AndroidConfig) -> Java
         compiler::CompileTarget::new(first_build_target.rust_triple()).unwrap(),
     )];
 
-    let target_data = compiler::RustcTargetData::new(&workspace, &requested_kinds[..]).unwrap();
+    let mut target_data = compiler::RustcTargetData::new(&workspace, &requested_kinds[..]).unwrap();
     let cli_features = resolver::CliFeatures::new_all(false);
     let ws_resolve = cargo::ops::resolve_ws_with_opts(
         &workspace,
-        &target_data,
+        &mut target_data,
         &requested_kinds,
         &cli_features,
         &specs,

--- a/src/ops/install.rs
+++ b/src/ops/install.rs
@@ -2,8 +2,8 @@ use super::BuildResult;
 use crate::config::AndroidConfig;
 use crate::ops::build;
 use cargo::core::Workspace;
-use cargo_util::ProcessBuilder;
 use cargo::util::CargoResult;
+use cargo_util::ProcessBuilder;
 use clap::ArgMatches;
 
 pub fn install(
@@ -17,7 +17,7 @@ pub fn install(
 
     for apk_path in build_result.target_to_apk_map.values() {
         drop(writeln!(
-            workspace.config().shell().err(),
+            workspace.gctx().shell().err(),
             "Installing apk '{}' to the device",
             apk_path.file_name().unwrap().to_string_lossy()
         ));


### PR DESCRIPTION
while trying to build with a new crate I got some error about needing some new thing only in the latest cargo. I noticed this is out of date so i updated the cargo to 0.8 and also ported it from clap 3 to clap 4.