### PR TITLE
Modernize the Android toolchain by upgrading to API 36

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.4"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "Philip Alldredge <philip@philipalldredge.com>", "Fedor Logachev <not.fl3@gmail.com>"]
 license = "MIT"
 description = "Cargo subcommand that allows you to build Android packages"
-repository = "https://github.com/not-fl3/cargo-apk"
+repository = "https://github.com/not-fl3/cargo-quad-apk"
 edition = "2018"
 
 [dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM archlinux
 
 RUN pacman -Syu --noconfirm
-RUN pacman -S --noconfirm jdk8-openjdk unzip wget cmake rustup openssl pkgconf
+RUN pacman -S --noconfirm jdk17-openjdk unzip wget cmake rustup openssl pkgconf
 
 # github override HOME, so here we are
 ENV RUSTUP_HOME=/usr/local/rustup \
@@ -28,8 +28,8 @@ RUN mkdir ${ANDROID_HOME} && \
     chown -R root:root /opt
 RUN mkdir -p ~/.android && touch ~/.android/repositories.cfg
 RUN yes | ${ANDROID_HOME}/tools/bin/sdkmanager "platform-tools" | grep -v = || true
-RUN yes | ${ANDROID_HOME}/tools/bin/sdkmanager "platforms;android-31" | grep -v = || true
-RUN yes | ${ANDROID_HOME}/tools/bin/sdkmanager "build-tools;31.0.0"  | grep -v = || true
+RUN yes | ${ANDROID_HOME}/tools/bin/sdkmanager "platforms;android-36" | grep -v = || true
+RUN yes | ${ANDROID_HOME}/tools/bin/sdkmanager "build-tools;36.0.0-rc5"  | grep -v = || true
 RUN ${ANDROID_HOME}/tools/bin/sdkmanager --update | grep -v = || true
 
 # Install Android NDK
@@ -52,7 +52,7 @@ RUN cargo install --path /root/cargo-apk
 RUN rm -rf /root/cargo-apk
 
 # Add build-tools to PATH, for apksigner
-ENV PATH="/opt/android-sdk-linux/build-tools/31.0.0/:${PATH}"
+ENV PATH="/opt/android-sdk-linux/build-tools/36.0.0-rc5/:${PATH}"
 
 # Make directory for user code
 RUN mkdir /root/src

--- a/README.md
+++ b/README.md
@@ -102,6 +102,21 @@ max_sdk_version = 18
 
 [[package.metadata.android.permission]]
 name = "android.permission.CAMERA"
+
+# An example of using a foreground service.
+# You must specify the relevant permissions required.
+[[package.metadata.android.permission]]
+name = "android.permission.FOREGROUND_SERVICE"
+[[package.metadata.android.permission]]
+name = "android.permission.FOREGROUND_SERVICE_REMOTE_MESSAGING"
+
+# Adds a service element in the manifest.
+[[package.metadata.android.service]]
+# Name of the Java file. Make sure it's included with quad.toml too.
+name = ".ForegroundService"
+# Optional flag but required for foreground services.
+foreground_service_type = "remoteMessaging"
+exported = false
 ```
 
 # Environment Variables

--- a/src/ops/build/util.rs
+++ b/src/ops/build/util.rs
@@ -252,10 +252,6 @@ pub struct JavaFiles {
     /// Extra .jar files to use in "dex" invocation
     /// "Runtime-time" Java dependency
     pub runtime_jar_files: Vec<(PathBuf, PathBuf)>,
-
-    /// List of services being appended to "metadata.android.service" with
-    /// "enabled: true" value
-    pub java_services: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -264,7 +260,6 @@ struct QuadToml {
     java_files: Option<Vec<String>>,
     comptime_jar_files: Option<Vec<String>>,
     runtime_jar_files: Option<Vec<String>>,
-    java_services: Option<Vec<String>>,
     // a special field being filled while toml parsing
     // do not really belong to a toml and this struct!
     #[serde(skip)]
@@ -331,7 +326,6 @@ pub fn collect_java_files(workspace: &Workspace, config: &AndroidConfig) -> Java
         java_files: vec![],
         comptime_jar_files: vec![],
         runtime_jar_files: vec![],
-        java_services: vec![],
     };
 
     let absolute_path = |root: &PathBuf, path: &str| {
@@ -361,9 +355,6 @@ pub fn collect_java_files(workspace: &Workspace, config: &AndroidConfig) -> Java
                 .extend(to_absolute(&toml.comptime_jar_files));
             res.runtime_jar_files
                 .extend(to_absolute(&toml.runtime_jar_files));
-            if let Some(ref java_services) = toml.java_services {
-                res.java_services.extend(java_services.iter().cloned());
-            }
         });
     res
 }


### PR DESCRIPTION
# My Issue

Android keeps suspending my app when inactive in the background. It's recommended to create a foreground service with the `foregroundServiceType` manifest attribute. This attribute is not available in the current SDK version which causes issues. Upgrading the SDK mandated updating the entire toolchain since much of it is now deprecated. See below for a list of changes.

# Commit Log

Modernize the Android toolchain by upgrading to API 36 which is the newest stable release.

This also requires updating from JDK 8 to JDK11. We select JDK17 since that's the current LTS.

I also noticed there was a conflicting way of specifying services via both quad.toml and Cargo.toml. I removed the quad.toml method, and we now use the directive in Cargo.toml (like for permissions).

The aapt tool is now deprecated, with aapt2 used instead. The command has changed slightly with the biggest change being that resources are compiled in a separate step.

rt.jar no longer exists. Instead we are using `-bootclasspath android_jar_path` directly. I believe this is correct and it seems to work.

In aapt2, the add subcommand no longer exists. Instead you use `zip -u` directly.

I found a bug where the `AndroidManifest.xml` values like permissions and services were comma separated in the XML introducing commas at the end of the line, so I removed that.
