### PR TITLE
Pass correct min_sdk_version to d8

### DIFF
--- a/src/ops/build.rs
+++ b/src/ops/build.rs
@@ -285,7 +285,9 @@ fn build_apks(
         }
         // otherwise "Type `java.lang.System` was not found" error
         d8_cmd.arg("--no-desugaring");
-        d8_cmd.arg("--min-api").arg("26");
+        d8_cmd
+            .arg("--min-api")
+            .arg(format!("{}", config.min_sdk_version));
 
         d8_cmd.cwd(&target_directory).exec()?;
 


### PR DESCRIPTION
This is currently hardcoded to 26 which means the generated dex's with use the 038 format which is incompatible with anything older than oreo